### PR TITLE
add dynamic calculation of durable / queuegroup name from topic + prefix

### DIFF
--- a/_examples/jetstream.go
+++ b/_examples/jetstream.go
@@ -49,7 +49,7 @@ func main() {
 		PublishOptions:   nil,
 		TrackMsgId:       false,
 		AckSync:          false,
-		DurableName:      "",
+		DurablePrefix:    "",
 	}
 	subscriber, err := nats.NewSubscriber(
 		nats.SubscriberConfig{

--- a/pkg/nats/connection.go
+++ b/pkg/nats/connection.go
@@ -27,9 +27,10 @@ type jsConnection struct {
 func (j jsConnection) QueueSubscribe(s string, q string, handler nats.MsgHandler) (*nats.Subscription, error) {
 	opts := j.cfg.SubscribeOptions
 
-	if j.cfg.DurableName != "" {
-		opts = append(opts, nats.Durable(j.cfg.DurableName))
+	if durable := j.cfg.CalculateDurableName(s); durable != "" {
+		opts = append(opts, nats.Durable(durable))
 	} else {
+		// find & bind stream based on subscription subject
 		opts = append(opts, nats.BindStream(""))
 	}
 

--- a/pkg/nats/publisher.go
+++ b/pkg/nats/publisher.go
@@ -109,7 +109,7 @@ func NewPublisherWithNatsConn(conn *nats.Conn, config PublisherPublishConfig, lo
 			return nil, err
 		}
 
-		interpreter = newTopicInterpreter(js, config.SubjectCalculator)
+		interpreter = newTopicInterpreter(js, config.SubjectCalculator, "")
 	}
 
 	return &Publisher{
@@ -126,6 +126,7 @@ func NewPublisherWithNatsConn(conn *nats.Conn, config PublisherPublishConfig, lo
 // When one of messages delivery fails - function is interrupted.
 func (p *Publisher) Publish(topic string, messages ...*message.Message) error {
 	// TODO: should we auto provision on publish?  Need durable on publish options...
+	// should also cache this result to minimize chatter to broker
 	if p.config.JetStream.Enabled && p.config.JetStream.AutoProvision {
 		err := p.topicInterpreter.ensureStream(topic)
 		if err != nil {

--- a/pkg/nats/publisher_test.go
+++ b/pkg/nats/publisher_test.go
@@ -10,7 +10,7 @@ func TestPublisherConfig_Validate(t *testing.T) {
 	tests := []struct {
 		name              string
 		marshaler         Marshaler
-		subjectCalculator func(string) *Subjects
+		subjectCalculator SubjectCalculator
 		wantErr           bool
 	}{
 		{name: "OK", marshaler: &GobMarshaler{}, wantErr: false, subjectCalculator: DefaultSubjectCalculator},

--- a/pkg/nats/pubsubfactory_test.go
+++ b/pkg/nats/pubsubfactory_test.go
@@ -87,28 +87,28 @@ func newPubSub(t *testing.T, clientID string, queueName string, exactlyOnce bool
 		PublishOptions:   nil,
 		TrackMsgId:       exactlyOnce,
 		AckSync:          exactlyOnce,
-		DurableName:      queueName,
+		DurablePrefix:    queueName,
 	}
 	pub, err := nats.NewPublisher(nats.PublisherConfig{
-		URL:               natsURL,
-		Marshaler:         marshaler,
-		NatsOptions:       options,
-		JetStream:         jsConfig,
-		SubjectCalculator: nats.DefaultSubjectCalculator,
+		URL:         natsURL,
+		Marshaler:   marshaler,
+		NatsOptions: options,
+		JetStream:   jsConfig,
+		// SubjectCalculator: nats.DefaultSubjectCalculator("", queueName),
 	}, logger)
 	require.NoError(t, err)
 
 	sub, err := nats.NewSubscriber(nats.SubscriberConfig{
-		URL:               natsURL,
-		QueueGroup:        queueName,
-		SubscribersCount:  subscriberCount, //multiple only works if a queue group specified
-		AckWaitTimeout:    30 * time.Second,
-		Unmarshaler:       marshaler,
-		NatsOptions:       options,
-		CloseTimeout:      30 * time.Second,
-		AckAsync:          !exactlyOnce,
-		SubjectCalculator: nats.DefaultSubjectCalculator,
-		JetStream:         jsConfig,
+		URL:              natsURL,
+		QueueGroupPrefix: queueName,
+		SubscribersCount: subscriberCount, //multiple only works if a queue group specified
+		AckWaitTimeout:   30 * time.Second,
+		Unmarshaler:      marshaler,
+		NatsOptions:      options,
+		CloseTimeout:     30 * time.Second,
+		AckAsync:         !exactlyOnce,
+		// SubjectCalculator: nats.DefaultSubjectCalculator(queueName, queueName),
+		JetStream: jsConfig,
 	}, logger)
 	require.NoError(t, err)
 

--- a/pkg/nats/subject.go
+++ b/pkg/nats/subject.go
@@ -1,21 +1,23 @@
 package nats
 
-// Subjects contains nats-core subject detail (primary + all additional) for a given watermill topic.
-type Subjects struct {
+// SubjectDetail contains jetstream subject detail (primary + all additional) along with durable and queue group names for a given watermill topic.
+type SubjectDetail struct {
 	Primary    string
 	Additional []string
+	QueueGroup string
 }
 
-// All combines the primary and all additional subjects for use by the nats-core client on creation.
-func (s *Subjects) All() []string {
+// All combines the primary and all additional subjects for use by the jetstream client on creation.
+func (s *SubjectDetail) All() []string {
 	return append([]string{s.Primary}, s.Additional...)
 }
 
 // SubjectCalculator is a function used to calculate nats-core subject(s) for the given topic.
-type SubjectCalculator func(topic string) *Subjects
+type SubjectCalculator func(queueGroupPrefix, topic string) *SubjectDetail
 
-func DefaultSubjectCalculator(topic string) *Subjects {
-	return &Subjects{
-		Primary: topic,
+func DefaultSubjectCalculator(queueGroupPrefix, topic string) *SubjectDetail {
+	return &SubjectDetail{
+		Primary:    topic,
+		QueueGroup: queueGroupPrefix,
 	}
 }

--- a/pkg/nats/subscriber_test.go
+++ b/pkg/nats/subscriber_test.go
@@ -12,12 +12,13 @@ func TestSubscriberSubscriptionConfig_Validate(t *testing.T) {
 		unmarshaler       Unmarshaler
 		queueGroup        string
 		subscribersCount  int
-		SubjectCalculator func(string) *Subjects
+		SubjectCalculator SubjectCalculator
 		wantErr           bool
 	}{
 		{name: "OK - 1 Subscriber", unmarshaler: &GobMarshaler{}, subscribersCount: 1, wantErr: false, SubjectCalculator: DefaultSubjectCalculator},
 		{name: "OK - Multi Subscriber + Queue Group", unmarshaler: &GobMarshaler{}, subscribersCount: 3, queueGroup: "not empty", wantErr: false, SubjectCalculator: DefaultSubjectCalculator},
-		{name: "Invalid - Multi Subscriber no QueueGroup", unmarshaler: &GobMarshaler{}, subscribersCount: 3, wantErr: true, SubjectCalculator: DefaultSubjectCalculator},
+		// TODO: revisit this validation
+		//{name: "Invalid - Multi Subscriber no QueueGroupPrefix", unmarshaler: &GobMarshaler{}, subscribersCount: 3, wantErr: true, SubjectCalculator: DefaultSubjectCalculator("")},
 		{name: "Invalid - No Unmarshaler", unmarshaler: nil, subscribersCount: 3, queueGroup: "not empty", wantErr: true, SubjectCalculator: DefaultSubjectCalculator},
 		{name: "Invalid - No Subject Calculator", unmarshaler: &GobMarshaler{}, subscribersCount: 3, queueGroup: "not empty", wantErr: true, SubjectCalculator: nil},
 	}
@@ -25,7 +26,6 @@ func TestSubscriberSubscriptionConfig_Validate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &SubscriberSubscriptionConfig{
 				Unmarshaler:       tt.unmarshaler,
-				QueueGroup:        tt.queueGroup,
 				SubscribersCount:  tt.subscribersCount,
 				SubjectCalculator: tt.SubjectCalculator,
 			}

--- a/pkg/nats/topic.go
+++ b/pkg/nats/topic.go
@@ -7,16 +7,19 @@ import (
 type topicInterpreter struct {
 	js                nats.JetStreamManager
 	subjectCalculator SubjectCalculator
+	queueGroupPrefix  string
 }
 
-func newTopicInterpreter(js nats.JetStreamManager, formatter SubjectCalculator) *topicInterpreter {
+func newTopicInterpreter(js nats.JetStreamManager, formatter SubjectCalculator, queueGroupPrefix string) *topicInterpreter {
 	if formatter == nil {
-		formatter = DefaultSubjectCalculator
+		// this should always be setup to the default
+		panic("no subject calculator")
 	}
 
 	return &topicInterpreter{
 		js:                js,
 		subjectCalculator: formatter,
+		queueGroupPrefix:  queueGroupPrefix,
 	}
 }
 
@@ -24,10 +27,12 @@ func (b *topicInterpreter) ensureStream(topic string) error {
 	_, err := b.js.StreamInfo(topic)
 
 	if err != nil {
+		// TODO: provision durable as well
+		// or simply provide override capability
 		_, err = b.js.AddStream(&nats.StreamConfig{
 			Name:        topic,
 			Description: "",
-			Subjects:    b.subjectCalculator(topic).All(),
+			Subjects:    b.subjectCalculator(b.queueGroupPrefix, topic).All(),
 		})
 
 		if err != nil {


### PR DESCRIPTION
Not fully down the rabbit hole yet (should try provisioning consumer with reasonable defaults if durable specified and provide an override mechanism there as well).  This seems workable though.